### PR TITLE
Update knative-serving ServiceMonitor port name from http-metrics to metrics

### DIFF
--- a/servicemonitor.yaml
+++ b/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: http-metrics
+    port: metrics
   namespaceSelector:
     matchNames:
     - knative-serving
@@ -27,7 +27,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: http-metrics
+    port: metrics
   namespaceSelector:
     matchNames:
     - knative-serving
@@ -45,7 +45,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: http-metrics
+    port: metrics
   namespaceSelector:
     matchNames:
     - knative-serving
@@ -63,7 +63,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: http-metrics
+    port: metrics
   namespaceSelector:
     matchNames:
     - knative-serving


### PR DESCRIPTION
This matches the port names in https://github.com/knative/serving/releases/download/knative-v1.11.0/serving-core.yaml